### PR TITLE
Fix flickering from unavailable dri driver

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -35,4 +35,24 @@
     alsa.support32Bit = true;
     pulse.enable = true;
   };
+
+  # Backport mutter patch which fix flickering in scenarios where the dri
+  # driver is unavailable.
+  #
+  #   https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3117
+  #
+  nixpkgs.overlays = [
+    (self: super: {
+      gnome = super.gnome.overrideScope' (gself: gsuper: {
+        mutter = gsuper.mutter.overrideAttrs (old: rec {
+           patches = (old.patches or [ ]) ++ [
+            (super.fetchpatch {
+              url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/626498348b96e7ebdb2ab90fb7d2b3446578333a.patch";
+              hash = "sha256-KLx0qbPwbooHEIMt0r2g/CjyWb2M5Mv3gNdA3YM6qJA";
+            })
+          ];
+        });
+      });
+    })
+  ];
 }


### PR DESCRIPTION
This PR backport [Gert van de Kraats](https://gitlab.gnome.org/GNOME/mutter/-/issues/2602) solution to fix flickering caused by the unavailable dri driver *(thank to PrinkeWasTaken for the video)*: 

https://github.com/snowflakelinux/snowflake-iso/assets/91024200/6f70d8b3-40e8-4623-b413-a159207d0fec


 

